### PR TITLE
Fixing critical Tux Paint crash on start when on Android S (31) and above

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,13 +12,13 @@ android {
     aaptOptions {
         ignoreAssetsPattern "nonexisting.file"
     }
-    compileSdkVersion 29
+    compileSdkVersion 32
     defaultConfig {
         if (buildAsApplication) {
             applicationId "org.tuxpaint"
         }
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 32
         externalNativeBuild {
             ndkBuild {
                 arguments "APP_PLATFORM=android-21"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     
     <!-- SDL asks for bluetooth in the default SDLActivity.java they provide -->
     <uses-permission android:name="android.permission.BLUETOOTH"/>
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT"/>
 
     <!-- Allow writing to external storage -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,9 +23,8 @@
                  android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
                  android:hardwareAccelerated="true" >
         <activity android:name="tuxpaintActivity"
-                  android:label="@string/app_name"
                   android:configChanges="keyboardHidden|orientation|screenSize"
-                  >
+                  android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -35,7 +34,7 @@
         <activity android:name=".ConfigActivity" 
 		  android:label="@string/app_config"
 		  android:icon="@drawable/ic_settings_black_36dp"
-		  >
+          android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/org/tuxpaint/reqpermsActivity.java
+++ b/app/src/main/java/org/tuxpaint/reqpermsActivity.java
@@ -1,18 +1,13 @@
 package org.tuxpaint;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.Locale;
-
+import android.Manifest;
+import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.app.*;
 import android.content.pm.PackageManager;
-import android.view.WindowManager.LayoutParams;
-import android.view.WindowManager;
 
 
 /* reqpermsActivity */
@@ -24,27 +19,34 @@ public class reqpermsActivity extends Activity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-	Log.v(TAG, "onCreate()");
-	super.onCreate(savedInstanceState);
+		Log.v(TAG, "onCreate()");
+		super.onCreate(savedInstanceState);
 
-	this.requestPermissions(new String[]{android.Manifest.permission.WRITE_EXTERNAL_STORAGE}, 2);
-	setContentView(R.layout.reqperms);
-
-	understoodButton = (Button)this.findViewById(R.id.buttonUnderstood);
-
-	understoodButton.setOnClickListener(new View.OnClickListener() {
-		public void onClick(View buttonView) {
-		    finish();
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+			this.requestPermissions(new String[]{ android.Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.BLUETOOTH_CONNECT }, 2);
+		} else {
+			this.requestPermissions(new String[]{ android.Manifest.permission.WRITE_EXTERNAL_STORAGE }, 2);
 		}
-	    });
+		setContentView(R.layout.reqperms);
+
+		understoodButton = (Button)this.findViewById(R.id.buttonUnderstood);
+
+		understoodButton.setOnClickListener(new View.OnClickListener() {
+			public void onClick(View buttonView) {
+				finish();
+			}
+		});
     }
 
     @Override
     public void onRequestPermissionsResult(int requestCode,
 					   String[] permissions, int[] grantResults) {
-	if (this.checkSelfPermission(android.Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
-	    finish();
-	}
+		if (this.checkSelfPermission(android.Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+					&& this.checkSelfPermission(Manifest.permission.BLUETOOTH_CONNECT) == PackageManager.PERMISSION_GRANTED) {
+				finish();
+			}
+		}
     }
 
     protected void onDestroy() {

--- a/app/src/main/java/org/tuxpaint/tuxpaintActivity.java
+++ b/app/src/main/java/org/tuxpaint/tuxpaintActivity.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import org.libsdl.app.SDLActivity;
 
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 import android.content.res.AssetManager;
@@ -20,15 +21,23 @@ public class tuxpaintActivity extends SDLActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         Log.v(TAG, "onCreate()");
-	super.onCreate(savedInstanceState);
-	mgr = getResources().getAssets();
-	managertojni(mgr);
-	if (android.os.Build.VERSION.SDK_INT > 22) {
-	    if (this.checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
-		Intent intent = new Intent(this, reqpermsActivity.class);
-		this.startActivity(intent);
-	    }
-	}
+
+        if (android.os.Build.VERSION.SDK_INT > 22) {
+            if (this.checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+                Intent intent = new Intent(this, reqpermsActivity.class);
+                this.startActivity(intent);
+            }
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            if (this.checkSelfPermission(Manifest.permission.BLUETOOTH_CONNECT) != PackageManager.PERMISSION_GRANTED) {
+                Intent intent = new Intent(this, reqpermsActivity.class);
+                this.startActivity(intent);
+            }
+        }
+
+        super.onCreate(savedInstanceState);
+        mgr = getResources().getAssets();
+        managertojni(mgr);
     }
 
     static {

--- a/app/src/main/res/layout/reqperms.xml
+++ b/app/src/main/res/layout/reqperms.xml
@@ -14,14 +14,15 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:gravity="center"
+        android:padding="32dp"
         android:orientation="horizontal" >
 
       <TextView
           android:id="@+id/viewPerms"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-	  android:minHeight="32dp"
-	  android:textSize="32sp"
+          android:minHeight="32dp"
+	      android:textSize="32sp"
           android:text="@string/Request_motivation" />
     </LinearLayout>
 
@@ -30,20 +31,16 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:gravity="center"
+        android:layout_marginTop="10dp"
         android:orientation="horizontal" >
       <Button
           android:id="@+id/buttonUnderstood"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-	  android:minHeight="32dp"
-	  android:textSize="32sp"
+          android:minHeight="32dp"
+	      android:textSize="32sp"
+          android:padding="10dp"
           android:text="@string/request_understood" />
     </LinearLayout>
-
-
-
-
-
-
   </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -81,7 +81,7 @@
     <string name="cancel">Discard changes</string>
 
     <!-- Request for permissions text and button -->
-    <string name="Request_motivation">Tux Paint needs storage access in order to save your drawings and to operate properly.</string>
+    <string name="Request_motivation">Tux Paint needs storage and Bluetooth access in order to save your drawings and to operate properly.</string>
     <string name="request_understood">Understood</string>
 
 

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -1,0 +1,89 @@
+@rem
+@rem Copyright 2015 the original author or authors.
+@rem
+@rem Licensed under the Apache License, Version 2.0 (the "License");
+@rem you may not use this file except in compliance with the License.
+@rem You may obtain a copy of the License at
+@rem
+@rem      https://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing, software
+@rem distributed under the License is distributed on an "AS IS" BASIS,
+@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@rem See the License for the specific language governing permissions and
+@rem limitations under the License.
+@rem
+
+@if "%DEBUG%" == "" @echo off
+@rem ##########################################################################
+@rem
+@rem  Gradle startup script for Windows
+@rem
+@rem ##########################################################################
+
+@rem Set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" setlocal
+
+set DIRNAME=%~dp0
+if "%DIRNAME%" == "" set DIRNAME=.
+set APP_BASE_NAME=%~n0
+set APP_HOME=%DIRNAME%
+
+@rem Resolve any "." and ".." in APP_HOME to make it shorter.
+for %%i in ("%APP_HOME%") do set APP_HOME=%%~fi
+
+@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"
+
+@rem Find java.exe
+if defined JAVA_HOME goto findJavaFromJavaHome
+
+set JAVA_EXE=java.exe
+%JAVA_EXE% -version >NUL 2>&1
+if "%ERRORLEVEL%" == "0" goto execute
+
+echo.
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:findJavaFromJavaHome
+set JAVA_HOME=%JAVA_HOME:"=%
+set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+
+if exist "%JAVA_EXE%" goto execute
+
+echo.
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:execute
+@rem Setup the command line
+
+set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
+
+
+@rem Execute Gradle
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %*
+
+:end
+@rem End local scope for the variables with windows NT shell
+if "%ERRORLEVEL%"=="0" goto mainEnd
+
+:fail
+rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
+rem the _cmd.exe /c_ return code!
+if  not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
+exit /b 1
+
+:mainEnd
+if "%OS%"=="Windows_NT" endlocal
+
+:omega


### PR DESCRIPTION
I tested Tux Paint on a Samsung S22+ and it immediately crashes when it starts due to a lack of android.permission.BLUETOOTH_CONNECT permission required by SDL. This permission is required as a run-time permission on Android API >= S.

To fix this I updated the code to require this permission when starting along with the external storage one.

I tested this fix on a S8+ and a S22+ to ensure there were no other breaking changes.

I also cleaned up the request permission layout to be more readable.