### PR TITLE
Changing Android save paths to now default to the 'external' dir from the device itself.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 32
-        versionCode 3
-        versionName "0.9.28.3"
+        versionCode 4
+        versionName "0.9.28.4"
         externalNativeBuild {
             ndkBuild {
                 arguments "APP_PLATFORM=android-21"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 32
-        versionCode 4
-        versionName "0.9.28.4"
+        versionCode 6
+        versionName "0.9.28.6"
         externalNativeBuild {
             ndkBuild {
                 arguments "APP_PLATFORM=android-21"

--- a/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -98,6 +98,7 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
 
     protected static int mCurrentOrientation;
     protected static Locale mCurrentLocale;
+    protected boolean isRequestingBluetoothPermission = false;
 
     // Handle the state of the native layer
     public enum NativeState {
@@ -281,7 +282,11 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
 
         mClipboardHandler = new SDLClipboardHandler();
 
-        mHIDDeviceManager = HIDDeviceManager.acquire(this);
+        // Bluetooth will fail on higher Android versions when starting while requesting
+        // the permissions. Skip it on the first run and let it come later.
+        if (!isRequestingBluetoothPermission) {
+            mHIDDeviceManager = HIDDeviceManager.acquire(this);
+        }
 
         // Set up the surface
         mSurface = new SDLSurface(getApplication());

--- a/app/src/main/java/org/tuxpaint/ConfigActivity.java
+++ b/app/src/main/java/org/tuxpaint/ConfigActivity.java
@@ -450,6 +450,12 @@ public class ConfigActivity extends Activity {
 	    e1.printStackTrace();
 	}
 
+	String externalPath = external.getAbsolutePath();
+	String externalExportPath = externalPath;
+	int foundIndex = externalExportPath.indexOf("/Android");
+	if (foundIndex > -1) {
+		externalExportPath = externalExportPath.substring(0, foundIndex) + "/Pictures/TuxPaint";
+	}
 
 	autosave = props.getProperty("autosave", "no");
 	sound = props.getProperty("sound", "no");
@@ -457,9 +463,9 @@ public class ConfigActivity extends Activity {
 	saveover = props.getProperty("saveover", "ask");
 	startblank = props.getProperty("startblank", "no");
 	newcolorsfirst = props.getProperty("newcolorsfirst", "yes");
-	savedir = props.getProperty("savedir", external.getAbsolutePath());
-	datadir = props.getProperty("datadir", external.getAbsolutePath());
-	exportdir = props.getProperty("exportdir", external.getAbsolutePath());
+	savedir = props.getProperty("savedir", externalPath);
+	datadir = props.getProperty("datadir", externalPath);
+	exportdir = props.getProperty("exportdir", externalExportPath);
 	lang = props.getProperty("lang", "en");
 	sysfonts = props.getProperty("sysfonts", "no");
 	print = props.getProperty("print", "no");

--- a/app/src/main/java/org/tuxpaint/tuxpaintActivity.java
+++ b/app/src/main/java/org/tuxpaint/tuxpaintActivity.java
@@ -30,6 +30,7 @@ public class tuxpaintActivity extends SDLActivity {
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             if (this.checkSelfPermission(Manifest.permission.BLUETOOTH_CONNECT) != PackageManager.PERMISSION_GRANTED) {
+                isRequestingBluetoothPermission = true;
                 requestPermissions = true;
             }
         }

--- a/app/src/main/jni/tuxpaint/src/tuxpaint.c
+++ b/app/src/main/jni/tuxpaint/src/tuxpaint.c
@@ -26411,6 +26411,12 @@ static void setup_config(char *argv[])
       picturesdir = GetUserImageDir();
 #elif __APPLE__
       picturesdir = strdup(apple_picturesPath());
+#elif __ANDROID__
+      picturesdir = strdup(SDL_AndroidGetExternalStoragePath());
+      char* substring = strstr(picturesdir, "/Android");
+      if (substring != NULL) {
+        strcpy(substring, "/Pictures");
+      }
 #else
       picturesdir = get_xdg_user_dir("PICTURES", "Pictures");
 #endif

--- a/app/src/main/jni/tuxpaint/src/tuxpaint.cfg-android
+++ b/app/src/main/jni/tuxpaint/src/tuxpaint.cfg-android
@@ -39,16 +39,10 @@ autosave=no
 
 saveover=ask
 
-savedir=/mnt/sdcard/TuxPaint
-
-datadir=/mnt/sdcard/TuxPaint
-
 nolockfile=yes
 
 onscreen-keyboard=yes
 
 onscreen-keyboard-layout=SYSTEM
-
-exportdir=/mnt/sdcard/Pictures/TuxPaint
 
 buttonsize=auto


### PR DESCRIPTION
On most devices this isn't actually on the SD card, as most no longer support that, and instead return `/storage/emulated/0/Android/data/org.tuxpaint/`

This directory is not accessible in API31 though from a file explorer, so the export path must be moved to the normal `/storage/emulated/0/Pictures/TuxPaint` position where most apps store pictures. This directory is only used when SDL_AndroidGetExternalStoragePath returns the internal path and not external.

The default of `/mnt/sdcard/TuxPaint` is removed entirely from the default config as it doesn't work for most devices and it's better to let the device calculated the default.

This is based on the [storage updates in API30](https://developer.android.com/about/versions/11/privacy/storage) and the differences between emulator and device [noted here](https://stackoverflow.com/questions/60710044/saving-images-in-external-storage-works-on-emulator-but-not-on-physical-phone-w). At some point we can probably remove `android.permission.WRITE_EXTERNAL_STORAGE` entirely since it's not even valid anymore.

I tested these changes on a physical S8+ (API28) and S22+ (API31) which don't have SD cards (the S22+ can't even have one anymore...) and they work as expected.