### PR TITLE
Bumping Android version to match 0.9.29 for Google Play release and c…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 32
-        versionCode 6
-        versionName "0.9.28.6"
+        versionCode 7
+        versionName "0.9.29.1"
         externalNativeBuild {
             ndkBuild {
                 arguments "APP_PLATFORM=android-21"

--- a/app/src/main/jni/platform_external_libpng/Android.mk
+++ b/app/src/main/jni/platform_external_libpng/Android.mk
@@ -33,7 +33,8 @@ my_src_files_arm := \
 			arm/palette_neon_intrinsics.c
 
 
-common_CFLAGS := -std=gnu89 #-fvisibility=hidden ## -fomit-frame-pointer
+# -std=gnu89 is not allowed from Android NDK build
+#common_CFLAGS := -std=gnu89 #-fvisibility=hidden ## -fomit-frame-pointer
 
 ifeq ($(TARGET_ARCH_ABI), armeabi-v7a)
 common_SRC_FILES += $(my_src_files_arm)


### PR DESCRIPTION
…ommenting out std=gnu89 flag which makes Android Studio constantly give warnings.