### PR TITLE
Adding a documentation browser to the config utility.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ else {
 }
 
 android {
-    namespace 'org.tuxpaint'
+    namespace = 'org.tuxpaint'
     compileSdkVersion 35
     defaultConfig {
         minSdkVersion 21
@@ -24,7 +24,7 @@ android {
     }
     packagingOptions {
         jniLibs {
-            useLegacyPackaging true
+            useLegacyPackaging = true
         }
     }
     buildTypes {
@@ -53,10 +53,10 @@ android {
         }
     }
     androidResources {
-        ignoreAssetsPattern 'nonexisting.file'
+        ignoreAssetsPattern = 'nonexisting.file'
     }
     lint {
-        abortOnError false
+        abortOnError = false
     }
     if (!project.hasProperty('EXCLUDE_NATIVE_LIBS')) {
         sourceSets.main {
@@ -87,7 +87,7 @@ task copyDataFiles(type: Copy) {
     from('src/main/jni/tuxpaint/data') {
         include '**/*.*'
     }
-    destinationDir(new File('src/main/assets/data'))
+    destinationDir = (new File('src/main/assets/data'))
 }
 task copyConfigFile(type: Copy) {
     from 'src/main/jni/tuxpaint/src/tuxpaint.cfg-android'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,6 +45,7 @@
         </activity>
         <activity android:name=".reqpermsActivity" />
         <activity android:name=".reqBTpermsActivity" />
+        <activity android:name=".DocViewerActivity" />
     </application> <!-- SDL asks for bluetooth in the default SDLActivity.java they provide -->
     <uses-feature android:glEsVersion="0x00020000" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />

--- a/app/src/main/java/org/tuxpaint/ConfigActivity.java
+++ b/app/src/main/java/org/tuxpaint/ConfigActivity.java
@@ -99,6 +99,7 @@ public class ConfigActivity extends Activity {
         Spinner osklayoutSpinner = null;
         ToggleButton stamprotationToggle = null;
         Button requestrevoquebtButton = null;
+        Button Docsbutton = null;
     Button okButton = null;
     Button cancelButton = null;
         AssetManager mgr;
@@ -454,6 +455,14 @@ public class ConfigActivity extends Activity {
 				};
 			}
 	});
+
+    Docsbutton = (Button)this.findViewById(R.id.buttonDocs);
+    Docsbutton.setOnClickListener(new View.OnClickListener() {
+			public void onClick(View buttonView) {
+startActivity(new Intent(ConfigActivity.this, DocViewerActivity.class));
+			}
+    });
+
 
 		okButton = (Button)this.findViewById(R.id.buttonOk);
 

--- a/app/src/main/java/org/tuxpaint/DocViewerActivity.java
+++ b/app/src/main/java/org/tuxpaint/DocViewerActivity.java
@@ -1,0 +1,71 @@
+package org.tuxpaint;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.webkit.WebSettings;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+import android.view.KeyEvent;
+import java.util.Locale;
+import java.io.IOException;
+
+public class DocViewerActivity extends Activity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.doc_viewer);
+
+        WebView webView = (WebView) findViewById(R.id.webView);
+        WebSettings webSettings = webView.getSettings();
+        webSettings.setBuiltInZoomControls(true);
+        webSettings.setDisplayZoomControls(false);
+        webSettings.setLoadWithOverviewMode(true);
+        webSettings.setUseWideViewPort(true);
+
+        webView.setWebViewClient(new WebViewClient());
+
+        String lang = Locale.getDefault().getLanguage();
+        String url = "file:///android_asset/docs/en/html/README.html";
+        String targetFolder = null;
+
+        if (lang.equals("es")) targetFolder = "es_ES.UTF-8";
+        else if (lang.equals("fr")) targetFolder = "fr_FR.UTF-8";
+        else if (lang.equals("gl")) targetFolder = "gl_ES.UTF-8";
+        else if (lang.equals("is")) targetFolder = "is_IS.UTF-8";
+        else if (lang.equals("ja")) targetFolder = "ja_JP.UTF-8";
+        else if (lang.equals("sq")) targetFolder = "sq_AL.UTF-8";
+        else if (lang.equals("sv")) targetFolder = "sv_SE.UTF-8";
+
+        if (targetFolder != null) {
+             try {
+                 String[] list = getAssets().list("docs/" + targetFolder);
+                 if (list != null && list.length > 0) {
+                     url = "file:///android_asset/docs/" + targetFolder + "/html/README.html";
+                 }
+             } catch (IOException e) {
+                 // Folder doesn't exist or error, fallback to en
+             }
+        }
+
+        webView.loadUrl(url);
+    }
+
+    @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        if (event.getAction() == KeyEvent.ACTION_DOWN) {
+            switch (keyCode) {
+                case KeyEvent.KEYCODE_BACK:
+                    WebView webView = (WebView) findViewById(R.id.webView);
+                    if (webView.canGoBack()) {
+                        webView.goBack();
+                    } else {
+                        finish();
+                    }
+                    return true;
+            }
+
+        }
+        return super.onKeyDown(keyCode, event);
+    }
+}

--- a/app/src/main/jni/tuxpaint/mkzip_assets.sh
+++ b/app/src/main/jni/tuxpaint/mkzip_assets.sh
@@ -48,6 +48,10 @@ then
 
     make LOCALE_PREFIX=tmpzip/locale install-gettext && \
 	cp -r data tmpzip/data && \
+	cp -r docs tmpzip/docs && \
+	cd magic/magic-docs && \
+	for langdir in *; do if [ -d $langdir ]; then mkdir ../../tmpzip/docs/$langdir/magic-docs && cp -r $langdir/html ../../tmpzip/docs/$langdir/magic-docs/; fi ; done && \
+	cd ../.. && \
 	cp -r fonts/locale tmpzip/data/fonts/locale && \
 	cp -r im tmpzip/data/im && \
 	cp -r osk tmpzip/data/osk && \

--- a/app/src/main/res/layout/config.xml
+++ b/app/src/main/res/layout/config.xml
@@ -543,5 +543,26 @@
           android:text="@string/ok" />
 
     </LinearLayout>
+
+
+    <LinearLayout
+        android:id="@+id/layoutDocs"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:orientation="horizontal" >
+
+        <TextView
+            android:id="@+id/viewDocs"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/Documentation" />
+      <Button
+          android:id="@+id/buttonDocs"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/explore_documentation" />
+
+        </LinearLayout>
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/config.xml
+++ b/app/src/main/res/layout/config.xml
@@ -3,6 +3,7 @@
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:background="#e5e5e5"
+    android:fitsSystemWindows="true"
     android:orientation="vertical" >
 
     <LinearLayout

--- a/app/src/main/res/layout/doc_viewer.xml
+++ b/app/src/main/res/layout/doc_viewer.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
+
+    <WebView
+        android:id="@+id/webView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -121,6 +121,8 @@
     <string name="Groupmagictools">Magic tools in one BIG list.</string>
     <string name="groupmagictools">Put the magic tools in sections.</string>
     <string name="ungroupmagictools">Put all the magic tools together.</string>
+    <string name="Documentation">Documentation</string>
+    <string name="explore_documentation">Browse</string>
 
 
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.3'
+        classpath 'com.android.tools.build:gradle:8.13.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Nov 13 22:58:21 EST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Also got trapped into a gradle update.
Java changes and browser interface are made mainly by Gemini.
This is my first serious approach to work with LLM, I hope I've managed to understand its code and to keep it small and clean.
Basically it creates a new activity for a webview and tweaks it to get the back button navigating the history like in a browser, instead of closing directly the activity.


The mkzipassets.sh changes are mine.

@automaton82 , could you test if it still compiles for you after the gradle updates? If needed I can try to downgrade them.
As for the docs browser, you will need an update of the assets, if you can't still run mkzipassets.sh, I've put a tar.gz with the updated assets at https://provant.freeddns.org/pere/public_html/Tux%20Paint/devel/20251201/assets.tar.gz about 115M

At the bottom of the config activity should show a "Browse" button that launches a webview for the docs, completely offline, the links that point outside the device will simply fail

Ouch! just noticed the button only shows in landscape mode, need to investigate why...

Thanks
Pere